### PR TITLE
Prefix Homebrew install with M1 arch flag

### DIFF
--- a/install/laptop
+++ b/install/laptop
@@ -15,6 +15,8 @@ trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
 
 set -e
 
+arch_type=$(uname -m)
+
 if [ ! -d "${HOME}/bin/" ]; then
   mkdir "${HOME}/bin"
 fi
@@ -61,9 +63,14 @@ gem_install_or_update() {
   fi
 }
 
+
 if ! command -v brew >/dev/null; then
   laptop_echo "Installing Homebrew ..."
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+  if [ "$arch_type" == "arm64" ]; then
+    arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+  else
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+  fi
 fi
 
 if brew list | grep -Fq brew-cask; then


### PR DESCRIPTION
Add condition for installing homebrew via Rosetta when on a Mac with M1 arm chip.